### PR TITLE
Add dataframe loading utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,10 @@ import argparse
 import logging
 import os
 
+import pandas as pd
+from snorkel.mtl.data import MultitaskDataset
+
+
 def str2list(v, dim=","):
     return [t.strip() for t in v.split(dim)]
 
@@ -67,3 +71,9 @@ def add_flags_from_config(parser, config_dict):
                 f"Could not add flag for param {param} because it was already present."
             )
     return parser
+
+
+def task_dataset_to_dataframe(dataset: MultitaskDataset) -> pd.DataFrame:
+    data_dict = dataset.X_dict
+    data_dict["labels"] = dataset.Y_dict["labels"]
+    return pd.DataFrame(data_dict)


### PR DESCRIPTION
* Factors out dataset loading from dataloader loading
* Adds task_dataset_to_dataframe to utils
* Ran black on dataloaders.py

Example usage
```python
import os

import models
from dataloaders import get_dataset
from tokenizer import get_tokenizer
from utils import task_dataset_to_dataframe

task_name = "WiC"
data_dir = os.environ["SUPERGLUEDATA"]
max_sequence_length = 256
bert_model = "bert-large-cased"
max_data_samples = 50

tokenizer = get_tokenizer(tokenizer_name)
dataset = get_dataset(
    data_dir, task_name, split, tokenizer, max_data_samples, max_sequence_length
)
wic_df = task_dataset_to_dataframe(dataset)
```

**Test plan**
Local testing of above example usage